### PR TITLE
rename: freeRTOS.h => FreeROTS.h for case sensitive fs in Linux/Mac

### DIFF
--- a/02_Example/ESP-IDF/03_ADC_Test/components/user_app/user_app.cpp
+++ b/02_Example/ESP-IDF/03_ADC_Test/components/user_app/user_app.cpp
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <freertos/freeRTOS.h>
+#include <freertos/FreeRTOS.h>
 #include <esp_log.h>
 #include "adc_bsp.h"
 

--- a/02_Example/ESP-IDF/04_I2C_PCF85063/components/user_app/user_app.cpp
+++ b/02_Example/ESP-IDF/04_I2C_PCF85063/components/user_app/user_app.cpp
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <freertos/freeRTOS.h>
+#include <freertos/FreeRTOS.h>
 #include <esp_log.h>
 #include "user_app.h"
 #include "i2c_equipment.h"

--- a/02_Example/ESP-IDF/05_I2C_SHTC3/components/user_app/user_app.cpp
+++ b/02_Example/ESP-IDF/05_I2C_SHTC3/components/user_app/user_app.cpp
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <freertos/freeRTOS.h>
+#include <freertos/FreeRTOS.h>
 #include <esp_log.h>
 #include "user_app.h"
 #include "i2c_equipment.h"

--- a/02_Example/ESP-IDF/06_SD_Card/components/user_app/user_app.cpp
+++ b/02_Example/ESP-IDF/06_SD_Card/components/user_app/user_app.cpp
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <string.h>
-#include <freertos/freeRTOS.h>
+#include <freertos/FreeRTOS.h>
 #include <esp_log.h>
 #include "user_app.h"
 #include "sdcard_bsp.h"

--- a/02_Example/ESP-IDF/07_Audio_Test/components/user_app/user_app.cpp
+++ b/02_Example/ESP-IDF/07_Audio_Test/components/user_app/user_app.cpp
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <freertos/freeRTOS.h>
+#include <freertos/FreeRTOS.h>
 #include <esp_log.h>
 
 #include "button_bsp.h"

--- a/02_Example/ESP-IDF/08_LVGL_V8_Test/components/user_app/user_app.cpp
+++ b/02_Example/ESP-IDF/08_LVGL_V8_Test/components/user_app/user_app.cpp
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <freertos/freeRTOS.h>
+#include <freertos/FreeRTOS.h>
 #include <esp_log.h>
 
 #include "user_app.h"

--- a/02_Example/ESP-IDF/09_LVGL_V9_Test/components/user_app/user_app.cpp
+++ b/02_Example/ESP-IDF/09_LVGL_V9_Test/components/user_app/user_app.cpp
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <freertos/freeRTOS.h>
+#include <freertos/FreeRTOS.h>
 #include <esp_log.h>
 
 #include "user_app.h"

--- a/02_Example/ESP-IDF/10_FactoryProgram/components/user_app/user_app.cpp
+++ b/02_Example/ESP-IDF/10_FactoryProgram/components/user_app/user_app.cpp
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <freertos/freeRTOS.h>
+#include <freertos/FreeRTOS.h>
 #include <esp_log.h>
 #include "button_bsp.h"
 #include "user_app.h"


### PR DESCRIPTION
it took me 2hrs last night figuring out this case sensitive things on Linux.
it will result in compiling error of missing header .

sync back for the community.